### PR TITLE
VMAP > Call of Duty GDT

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 This is a 3rd generation fork, first created by Rictus and then Forked by DankParrot/Alphyne. These are a set of scripts to help convert Source 1 assets to Source 2 with ease, partly using the tools Valve already have available, and using a materials script that takes a lot of guesswork. These tools were intended to be used with the Source 2 Filmmaker, but can be applied to any Source 2 project.
 
+Below is a list of branches that have been tested with the tool:
+- Source Filmmaker Branch (most content from this build is stable and should work nicely.)
+
+Below is a list of branches that DON'T work with this tool (in SteamVR):
+- Left 4 Dead 2 (most content works, but player models crash the engine.)
+
 ## vmt_to_vmat.py
 
 A simple Python 3.7 batch converter to convert Source 1 .vmt material files to the Source 2 .vmat format.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The material parameters does not map one to one, so it won't convert the materia
 
 I've taken some liberties with the available Standard VR shader in SteamVR as my guideline, and converting a specular map from Source 1 to PBR in Source 2 is not going to be totally 1 to 1. However, it does look pretty good in most use cases, and I'd reccomend modifying the script to your needs depending on what game/art style you're working with. For instance, I've had to dull the ReflectanceRange across the board for HL2 assets, which I didn't need to do for L4D2 assets.
 
-To use, first modify global_vars.txt to include your game's content path. Then, run the script using `python vmt_to_vmat.py modName`, replacing modName with the name of your mod's folder (i.e. hl2, left4dead2, usermod, etc.)
+To use, first modify global_vars.txt to include your game's content path. Then, run the script using `python vmt_to_vmat.py modName`, replacing modName with the name of your mod's folder (i.e. hl2, left4dead2, usermod, etc.) You may also add a second argument at the end if you wish to specify a specific directory.
 
 ## mdl_to_vmdl.py
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ The material parameters does not map one to one, so it won't convert the materia
 
 I've taken some liberties with the available Standard VR shader in SteamVR as my guideline, and converting a specular map from Source 1 to PBR in Source 2 is not going to be totally 1 to 1. However, it does look pretty good in most use cases, and I'd reccomend modifying the script to your needs depending on what game/art style you're working with. For instance, I've had to dull the ReflectanceRange across the board for HL2 assets, which I didn't need to do for L4D2 assets.
 
+To use, first modify global_vars.txt to include your game's content path. Then, run the script using `python vmt_to_vmat.py modName`, replacing modName with the name of your mod's folder (i.e. hl2, left4dead2, usermod, etc.)
+
 ## mdl_to_vmdl.py
 
 Generates a .vmdl file that will tell Source 2 to import its accompanying .mdl file.
 
 You must leave the original .mdl files for the .vmdls to compile.
 
-Run the script with a __directory__ like `py mdl_to_vmdl.py models` and it will fill that directoy with .vmdls. Make sure you leave all the MDLs in tact so Source 2 can convert them.
+Run the script with a __directory__ like `python mdl_to_vmdl.py models` and it will fill that directoy with .vmdls. Make sure you leave all the MDLs in tact so Source 2 can convert them.
 
 ## qc_to_vmdl.py
 
@@ -41,8 +43,8 @@ Step 2: Extract the files you desire using GCFScape to the __CONTENT__ root of t
 
 Step 3: Using VTFEdit, extract the textures from the .vtf files into .tga using the "Convert Folder" functionality under tools. Again, make sure these TGAs follow the exact same layout as Source 1.
 
-Step 4: Run mdl_to_vmdl.py using the commands and instructions listed above.
+Step 4: __Modify global_vars.txt to include the details of your project's files.__
 
-Step 5: Run vmt_to_vmat.py using the commands and instructions listed above.
+Step 5: First run mdl_to_vmdl.py, then run vmt_to_vmat.py, using the instructions above.
 
 Step 6: Open your mod. Your files should now attempt to convert as you load them, but sometimes doing this process too fast (i.e. scrolling through the Content Browser super quick) will crash the game. Please take care not to break your system while loading these files.

--- a/README.md
+++ b/README.md
@@ -1,28 +1,37 @@
 # source2utils
 
-This is a 3rd generation fork, first created by Rictus and then Forked by DankParrot/Alphyne. These are a set of scripts to help convert Source 1 assets to Source 2 with ease, partly using the tools Valve already have available, and using a materials script that takes a lot of guesswork.
-These scripts are meant to run using Python 3.7, and also require an installation of the Python Image Library. They are provided with no warranty.
+This is a 3rd generation fork, first created by Rictus and then Forked by DankParrot/Alphyne. These are a set of scripts to help convert Source 1 assets to Source 2 with ease, partly using the tools Valve already have available, and using a materials script that takes a lot of guesswork. These tools were intended to be used with the Source 2 Filmmaker, but can be applied to any Source 2 project.
 
-## System Requirements:
-Python 3.7 or later
-Python Image Library (PIL)
-
-# vmt_to_vmat.py
+## vmt_to_vmat.py
 
 A simple Python 3.7 batch converter to convert Source 1 .vmt material files to the Source 2 .vmat format.
 The material parameters does not map one to one, so it won't convert the materials perfectly. 
 I've taken some liberties with the available Standard VR shader in SteamVR as my guideline, and converting a specular map from Source 1 to PBR in Source 2 is not going to be totally 1 to 1. However, it does look pretty good in most use cases, and I'd reccomend modifying the script to your needs depending on what game/art style you're working with. For instance, I've had to dull the ReflectanceRange across the board for HL2 assets, which I didn't need to do for L4D2 assets.
 
-# mdl_to_vmdl.py
+## mdl_to_vmdl.py
 
 Generates a .vmdl file that will tell Source 2 to import its accompanying .mdl file.
 You must leave the original .mdl files for the .vmdls to compile.
 
 Run the script with a __directory__ like `py mdl_to_vmdl.py models` and it will fill that directoy with .vmdls. Make sure you leave all the MDLs in tact so Source 2 can convert them.
 
-# qc_to_vmdl.py
+## qc_to_vmdl.py
 
 (deprecated)
 
 An older attempt at converting models before I figured out how to directly import .mdl files.
 You can use this as a base if you want to import the source files manually.
+
+## System Requirements:
+Python 3.7 or later
+Python Image Library (PIL)
+The SteamVR Workshop Tools (you do not need VR to run these!)
+A Source 1 game's content
+
+# Usage:
+Step 1: Create your mod in the SteamVR Workshop Tools (see [this guide](https://steamcommunity.com/sharedfiles/filedetails/?id=2014947360) on how to make this happen for the S2FM.) I would recommend naming the mod the same name as the name you're pulling files from, especially if you're batch converting a whole game.
+Step 2: Extract the files you desire using GCFScape to the __CONTENT___ root of the mod, i.e. SteamVR/tools/steamvr_environments/content/steamtours_addons/hl2, following the same format as Source 1.
+Step 3: Using VTFEdit, extract the textures from the .vtf files into .tga using the "Convert Folder" functionality under tools. Again, make sure these TGAs follow the exact same layout as Source 1.
+Step 4: Run mdl_to_vmdl.py using the commands and instructions listed above.
+Step 5: Run vmt_to_vmat.py using the commands and instructions listed above.
+Step 6: Open your mod. Your files should now attempt to convert as you load them, but sometimes doing this process too fast (i.e. scrolling through the Content Browser super quick) will crash the game. Please take care not to break your system while loading these files.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A Source 1 game's content
 # Usage:
 Step 1: Create your mod in the SteamVR Workshop Tools (see [this guide](https://steamcommunity.com/sharedfiles/filedetails/?id=2014947360) on how to make this happen for the S2FM.) I would recommend naming the mod the same name as the name you're pulling files from, especially if you're batch converting a whole game.
 
-Step 2: Extract the files you desire using GCFScape to the __CONTENT___ root of the mod, i.e. SteamVR/tools/steamvr_environments/content/steamtours_addons/hl2, following the same format as Source 1.
+Step 2: Extract the files you desire using GCFScape to the __CONTENT__ root of the mod, i.e. SteamVR/tools/steamvr_environments/content/steamtours_addons/hl2, following the same format as Source 1.
 
 Step 3: Using VTFEdit, extract the textures from the .vtf files into .tga using the "Convert Folder" functionality under tools. Again, make sure these TGAs follow the exact same layout as Source 1.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Step 3: Using VTFEdit, extract the textures from the .vtf files into .tga using 
 
 Step 3.5: Add a new empty .txt file to the root of your mod's content file, called convertedBumpmaps.txt. This file stores the filenames of the .tga files that have been converted to S2's flipped green channel format.
 
-Step 4: __Modify global_vars.txt to include the details of your project's files.__
+Step 4: __Modify global_vars.txt to include the details of your project's files, pointing to your content/steamtours_addon/ folder.__
 
 Step 5: First run mdl_to_vmdl.py, then run vmt_to_vmat.py, using the instructions above.
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,15 @@ This is a 3rd generation fork, first created by Rictus and then Forked by DankPa
 ## vmt_to_vmat.py
 
 A simple Python 3.7 batch converter to convert Source 1 .vmt material files to the Source 2 .vmat format.
+
 The material parameters does not map one to one, so it won't convert the materials perfectly. 
+
 I've taken some liberties with the available Standard VR shader in SteamVR as my guideline, and converting a specular map from Source 1 to PBR in Source 2 is not going to be totally 1 to 1. However, it does look pretty good in most use cases, and I'd reccomend modifying the script to your needs depending on what game/art style you're working with. For instance, I've had to dull the ReflectanceRange across the board for HL2 assets, which I didn't need to do for L4D2 assets.
 
 ## mdl_to_vmdl.py
 
 Generates a .vmdl file that will tell Source 2 to import its accompanying .mdl file.
+
 You must leave the original .mdl files for the .vmdls to compile.
 
 Run the script with a __directory__ like `py mdl_to_vmdl.py models` and it will fill that directoy with .vmdls. Make sure you leave all the MDLs in tact so Source 2 can convert them.
@@ -24,14 +27,22 @@ You can use this as a base if you want to import the source files manually.
 
 ## System Requirements:
 Python 3.7 or later
+
 Python Image Library (PIL)
+
 The SteamVR Workshop Tools (you do not need VR to run these!)
+
 A Source 1 game's content
 
 # Usage:
 Step 1: Create your mod in the SteamVR Workshop Tools (see [this guide](https://steamcommunity.com/sharedfiles/filedetails/?id=2014947360) on how to make this happen for the S2FM.) I would recommend naming the mod the same name as the name you're pulling files from, especially if you're batch converting a whole game.
+
 Step 2: Extract the files you desire using GCFScape to the __CONTENT___ root of the mod, i.e. SteamVR/tools/steamvr_environments/content/steamtours_addons/hl2, following the same format as Source 1.
+
 Step 3: Using VTFEdit, extract the textures from the .vtf files into .tga using the "Convert Folder" functionality under tools. Again, make sure these TGAs follow the exact same layout as Source 1.
+
 Step 4: Run mdl_to_vmdl.py using the commands and instructions listed above.
+
 Step 5: Run vmt_to_vmat.py using the commands and instructions listed above.
+
 Step 6: Open your mod. Your files should now attempt to convert as you load them, but sometimes doing this process too fast (i.e. scrolling through the Content Browser super quick) will crash the game. Please take care not to break your system while loading these files.

--- a/README.md
+++ b/README.md
@@ -1,33 +1,26 @@
 # source2utils
 
-This is a 3rd generation fork, first created by Rictus and then Forked by DankParrot/Alphyne.
-These scripts are meant to run using Python 3.7, and also require an installation of the Python Image Library
+This is a 3rd generation fork, first created by Rictus and then Forked by DankParrot/Alphyne. These are a set of scripts to help convert Source 1 assets to Source 2 with ease, partly using the tools Valve already have available, and using a materials script that takes a lot of guesswork.
+These scripts are meant to run using Python 3.7, and also require an installation of the Python Image Library. They are provided with no warranty.
 
-# System Requirements:
+## System Requirements:
 Python 3.7 or later
 Python Image Library (PIL)
 
-## vmt_to_vmat.py
+# vmt_to_vmat.py
 
 A simple Python 3.7 batch converter to convert Source 1 .vmt material files to the Source 2 .vmat format.
 The material parameters does not map one to one, so it won't convert the materials perfectly. 
 I've taken some liberties with the available Standard VR shader in SteamVR as my guideline, and converting a specular map from Source 1 to PBR in Source 2 is not going to be totally 1 to 1. However, it does look pretty good in most use cases, and I'd reccomend modifying the script to your needs depending on what game/art style you're working with. For instance, I've had to dull the ReflectanceRange across the board for HL2 assets, which I didn't need to do for L4D2 assets.
 
-# Usage:
-Modify the script to include your personal game's content root (i.e. SteamVR/tools/steamvr_environments/content/steamtours_addons/) in the PATH_TO_GAME_CONTENT_ROOT variable.
-Run the script using your mod name as an argument, i.e.:
-python vmt_to_vmat.py left4dead2_movies
-You can also add to that an argument for a specific path to a material file or folder, i.e.:
-python vmt_to_vmat.py left4dead2_movies "C:\Program Files (x86)\Steam\steamapps\common\SteamVR\tools\steamvr_environments\content\steamtours_addons\hl2\materials\models\airboat"
-
-## mdl_to_vmdl.py
+# mdl_to_vmdl.py
 
 Generates a .vmdl file that will tell Source 2 to import its accompanying .mdl file.
 You must leave the original .mdl files for the .vmdls to compile.
 
 Run the script with a __directory__ like `py mdl_to_vmdl.py models` and it will fill that directoy with .vmdls. Make sure you leave all the MDLs in tact so Source 2 can convert them.
 
-## qc_to_vmdl.py
+# qc_to_vmdl.py
 
 (deprecated)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+***HEY! These utilities are still broken in a lot of ways and will fail very often. Please use with the understanding that it doesn't perfectly convert files yet and will only go through certain texture sets perfectly. This program has so far been tested on L4D2 content and HL2 content, both pulled from Source 1 Filmmaker's files and DLC.***
+
 # source2utils
 
 This is a 3rd generation fork, first created by Rictus and then Forked by DankParrot/Alphyne. These are a set of scripts to help convert Source 1 assets to Source 2 with ease, partly using the tools Valve already have available, and using a materials script that takes a lot of guesswork. These tools were intended to be used with the Source 2 Filmmaker, but can be applied to any Source 2 project.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
 # source2utils
 
+This is a 3rd generation fork, first created by Rictus and then Forked by DankParrot/Alphyne.
+These scripts are meant to run using Python 3.7, and also require an installation of the Python Image Library
+
+# System Requirements:
+Python 3.7 or later
+Python Image Library (PIL)
+
 ## vmt_to_vmat.py
 
 A simple Python 3.7 batch converter to convert Source 1 .vmt material files to the Source 2 .vmat format.
 The material parameters does not map one to one, so it won't convert the materials perfectly. 
+I've taken some liberties with the available Standard VR shader in SteamVR as my guideline, and converting a specular map from Source 1 to PBR in Source 2 is not going to be totally 1 to 1. However, it does look pretty good in most use cases, and I'd reccomend modifying the script to your needs depending on what game/art style you're working with. For instance, I've had to dull the ReflectanceRange across the board for HL2 assets, which I didn't need to do for L4D2 assets.
 
-Usage: Run the script with material files or directories contaioning them as argumnets (or simply drag and drop the file/dir on the script file). WARNING: Will overwrite any vmat files it converts.
+# Usage:
+Modify the script to include your personal game's content root (i.e. SteamVR/tools/steamvr_environments/content/steamtours_addons/) in the PATH_TO_GAME_CONTENT_ROOT variable.
+Run the script using your mod name as an argument, i.e.:
+python vmt_to_vmat.py left4dead2_movies
+You can also add to that an argument for a specific path to a material file or folder, i.e.:
+python vmt_to_vmat.py left4dead2_movies "C:\Program Files (x86)\Steam\steamapps\common\SteamVR\tools\steamvr_environments\content\steamtours_addons\hl2\materials\models\airboat"
 
 ## mdl_to_vmdl.py
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Step 2: Extract the files you desire using GCFScape to the __CONTENT__ root of t
 
 Step 3: Using VTFEdit, extract the textures from the .vtf files into .tga using the "Convert Folder" functionality under tools. Again, make sure these TGAs follow the exact same layout as Source 1.
 
+Step 3.5: Add a new empty .txt file to the root of your mod's content file, called convertedBumpmaps.txt. This file stores the filenames of the .tga files that have been converted to S2's flipped green channel format.
+
 Step 4: __Modify global_vars.txt to include the details of your project's files.__
 
 Step 5: First run mdl_to_vmdl.py, then run vmt_to_vmat.py, using the instructions above.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can use this as a base if you want to import the source files manually.
 ## System Requirements:
 Python 3.7 or later
 
-Python Image Library (PIL)
+Python Image Library (PIL)  5.4.1
 
 The SteamVR Workshop Tools (you do not need VR to run these!)
 

--- a/utils/extract_alpha_channel.py
+++ b/utils/extract_alpha_channel.py
@@ -1,0 +1,30 @@
+from __future__ import print_function
+import os, sys
+from PIL import Image
+
+image_path = "alphatesting.tga"
+mask_path = "alphatesting_alpha.png"
+
+# Open the image and convert it to RGBA, just in case it was indexed
+image = Image.open(image_path).convert('RGBA')
+
+# Extract just the alpha channel
+alpha = image.split()[-1]
+
+# Unfortunately the alpha channel is still treated as such and can't be dumped
+# as-is
+
+# Create a new image with an opaque black background
+bg = Image.new("RGBA", image.size, (0,0,0,255))
+
+# Copy the alpha channel to the new image using itself as the mask
+bg.paste(alpha, mask=alpha)
+
+# Since the bg image started as RGBA, we can save some space by converting it
+# to grayscale ('L') Optionally, we can convert the image to be indexed which
+# saves some more space ('P') In my experience, converting directly to 'P'
+# produces both the Gray channel and an Alpha channel when viewed in GIMP,
+# althogh the file sizes is about the same
+bg.convert('L').convert('P', palette=Image.ADAPTIVE, colors=8).save(
+                                                                mask_path,
+                                                                optimize=True)

--- a/utils/global_vars.txt
+++ b/utils/global_vars.txt
@@ -1,0 +1,1 @@
+gameContentRoot = C:\Program Files (x86)\Steam\steamapps\common\SteamVR\tools\steamvr_environments\content\steamtours_addons\

--- a/utils/global_vars.txt
+++ b/utils/global_vars.txt
@@ -1,1 +1,5 @@
+// NOTE: Keep your variables here as plain as possible. Adding things like quotation marks may cause your script to flip out.
+// Adjust to your own root content folder
 gameContentRoot = C:\Program Files (x86)\Steam\steamapps\common\SteamVR\tools\steamvr_environments\content\steamtours_addons\
+// Default reflectance range, defines how strong the envMap effect is. Usually needs to be toned down for PBR shaders in S2.
+reflectanceRange = g_vReflectanceRange "[0.000 0.050]"

--- a/utils/mdl_to_vmdl.py
+++ b/utils/mdl_to_vmdl.py
@@ -6,18 +6,24 @@ import re, sys, os
 INPUT_FILE_EXT = '.mdl'
 OUTPUT_FILE_EXT = '.vmdl'
 # this leads to the root of the game folder, i.e. dota 2 beta/content/dota_addons/, make sure to remember the final slash!!
-PATH_TO_GAME_CONTENT_ROOT = "C:/Program Files (x86)/Steam/steamapps/common/SteamVR/tools/steamvr_environments/content/steamtours_addons/"
-PATH_TO_CONTENT_ROOT = PATH_TO_GAME_CONTENT_ROOT + sys.argv[1] + "/"
-
-if(PATH_TO_GAME_CONTENT_ROOT == ""):
-    print("ERROR: Please open mdl_to_vmdl in your favorite text editor, and modify PATH_TO_GAME_CONTENT_ROOT to lead to your games content files (i.e. ...\steamvr_environments\content\steamtours_addons\)")
-    quit()
+PATH_TO_GAME_CONTENT_ROOT = ""
+PATH_TO_CONTENT_ROOT = ""
     
 VMDL_BASE = '''<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
 {
     m_sMDLFilename = "<mdl>"
 }
 '''
+
+def text_parser(filepath, separator="="):
+    return_dict = {}
+    with open(filepath, "r") as f:
+        for line in f:
+            if not line.startswith("//") or line in ['\n', '\r\n'] or line.strip() == '':
+                line = line.replace('\t', '').replace('\n', '')
+                line = line.split(separator)
+                return_dict[line[0]] = line[1]
+    return return_dict
 
 def walk_dir(dirname):
     files = []
@@ -31,6 +37,10 @@ def walk_dir(dirname):
 
 abspath = ''
 files = []
+globalVars = text_parser("global_vars.txt", " = ")
+PATH_TO_GAME_CONTENT_ROOT = globalVars["gameContentRoot"]
+PATH_TO_CONTENT_ROOT = PATH_TO_GAME_CONTENT_ROOT + sys.argv[1] + "/"
+print(PATH_TO_CONTENT_ROOT)
 
 # recursively search all dirs and files
 abspath = os.path.abspath(PATH_TO_CONTENT_ROOT)
@@ -58,6 +68,14 @@ def relative_path(s, base):
 
 def get_mesh_name(file):
     return os.path.splitext(os.path.basename(fix_path(file)))[0]
+
+if(PATH_TO_GAME_CONTENT_ROOT == ""):
+    print("ERROR: Please open vmt_to_vmat in your favorite text editor, and modify PATH_TO_GAME_CONTENT_ROOT to lead to your games content files (i.e. ...\steamvr_environments\content\steamtours_addons\)")
+    quit()
+    
+print('Source 2 VMDL Generator! By Rectus via Github.')
+print('Initially forked by Alpyne, this version by caseytube.')
+print('--------------------------------------------------------------------------------------------------------')
 
 for filename in files:
     out_name = filename.replace(INPUT_FILE_EXT, OUTPUT_FILE_EXT)

--- a/utils/mdl_to_vmdl.py
+++ b/utils/mdl_to_vmdl.py
@@ -1,8 +1,18 @@
+# cmd command: python mdl_to_vmdl.py "C:\Program Files (x86)\Steam\steamapps\common\SteamVR\tools\steamvr_environments\content\steamtours_addons\l4d2_converted\models"
+# MUST run in the models folder
+
 import re, sys, os
 
 INPUT_FILE_EXT = '.mdl'
 OUTPUT_FILE_EXT = '.vmdl'
+# this leads to the root of the game folder, i.e. dota 2 beta/content/dota_addons/, make sure to remember the final slash!!
+PATH_TO_GAME_CONTENT_ROOT = "C:/Program Files (x86)/Steam/steamapps/common/SteamVR/tools/steamvr_environments/content/steamtours_addons/"
+PATH_TO_CONTENT_ROOT = PATH_TO_GAME_CONTENT_ROOT + sys.argv[1] + "/"
 
+if(PATH_TO_GAME_CONTENT_ROOT == ""):
+    print("ERROR: Please open mdl_to_vmdl in your favorite text editor, and modify PATH_TO_GAME_CONTENT_ROOT to lead to your games content files (i.e. ...\steamvr_environments\content\steamtours_addons\)")
+    quit()
+    
 VMDL_BASE = '''<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
 {
     m_sMDLFilename = "<mdl>"
@@ -23,14 +33,12 @@ abspath = ''
 files = []
 
 # recursively search all dirs and files
-for path in sys.argv:
-    abspath = os.path.abspath(path)
-    if os.path.isdir(abspath):
-        files.extend(walk_dir(abspath))
-        break
-    #else:
-    #    if abspath.lower().endswith(INPUT_FILE_EXT):
-    #        files.append(abspath)
+abspath = os.path.abspath(PATH_TO_CONTENT_ROOT)
+if os.path.isdir(abspath):
+    files.extend(walk_dir(abspath))
+#else:
+#    if abspath.lower().endswith(INPUT_FILE_EXT):
+#        files.append(abspath)
 
 def putl(f, line, indent = 0):
     f.write(('\t' * indent) + line + '\r\n')
@@ -52,13 +60,14 @@ def get_mesh_name(file):
     return os.path.splitext(os.path.basename(fix_path(file)))[0]
 
 for filename in files:
-    
     out_name = filename.replace(INPUT_FILE_EXT, OUTPUT_FILE_EXT)
     if os.path.exists(out_name): continue
 
-    print('Importing ', os.path.basename(filename))
+    print('Importing', os.path.basename(filename))
 
     out = sys.stdout
-    mdl_path = fix_path(filename.replace(abspath, os.path.basename(abspath)))
+    
+    mdl_path = fix_path(filename.replace(abspath, ""))
+    
     with open(out_name, 'w') as out:
         putl(out, VMDL_BASE.replace('<mdl>', mdl_path).replace((' ' * 4), '\t'))

--- a/utils/vmt_to_vmat.py
+++ b/utils/vmt_to_vmat.py
@@ -331,9 +331,9 @@ for fileName in fileList:
     
     if validMaterial:
         vmatFileName = fileName.replace('.vmt', '') + '.vmat'
-        #if os.path.exists(vmatFileName):
-        #    print('+ File already exists. Skipping!')
-        #    continue
+        if os.path.exists(vmatFileName):
+            print('+ File already exists. Skipping!')
+            continue
         
         print('+ Converting ' + os.path.basename(fileName))
         with open(vmatFileName, 'w') as vmatFile:

--- a/utils/vmt_to_vmat.py
+++ b/utils/vmt_to_vmat.py
@@ -53,11 +53,11 @@ materialTypes = [
 "eyes",
 "eyeball",
 #"modulate",
-#"water", #TODO: integrate water/refract shaders into this script
+"water", #TODO: integrate water/refract shaders into this script
 "refract",
 "worldvertextransition",
 #"lightmapped_4wayblend",
-#"unlittwotexture", #TODO: Fix this one too, used by some hl2 mats
+"unlittwotexture", #TODO: make this system functional
 #"lightmappedreflective",
 #"cables"
 ]

--- a/utils/vmt_to_vmat.py
+++ b/utils/vmt_to_vmat.py
@@ -1,5 +1,3 @@
-
-
 # Converts Source 1 .vmt material files to simple Source 2 .vmat files.
 #
 # Copyright (c) 2016 Rectus
@@ -22,12 +20,58 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+# Usage Instructions:
+# python vmt_to_vmat.py MODNAME OPTIONAL_PATH_TO_FOLDER
+
 import sys
 import os
+import os.path
+from os import path
 import re
+from PIL import Image
+import PIL.ImageOps
 
-SHADER = 'vr_standard' # What shader to use.
-TEXTURE_FILEEXT = '.tga' # File format of the textures.
+# What shader to use.
+SHADER = 'vr_standard' 
+# File format of the textures.
+TEXTURE_FILEEXT = '.tga' 
+# substring added after an alpha map's name, but before the extension
+MAP_SUBSTRING = '_alpha' 
+# this leads to the root of the game folder, i.e. dota 2 beta/content/dota_addons/, make sure to remember the final slash!!
+PATH_TO_GAME_CONTENT_ROOT = ""
+PATH_TO_CONTENT_ROOT = ""
+
+# material types need to be lowercase because python is a bit case sensitive
+materialTypes = [
+"vertexlitgeneric",
+"unlitgeneric",
+"lightmappedgeneric",
+"patch",
+#"modulate",
+#"water", #TODO: integrate water/refract shaders into this script
+#"refract"
+#"lightmapped_4wayblend",
+#"lightmappedreflective",
+#"cables"
+]
+ignoreList = [
+"vertexlitgeneric_hdr_dx9",
+"vertexlitgeneric_dx9",
+"vertexlitgeneric_dx8",
+"vertexlitgeneric_dx7",
+"lightmappedgeneric_hdr_dx9",
+"lightmappedgeneric_dx9",
+"lightmappedgeneric_dx8",
+"lightmappedgeneric_dx7",
+]
+
+def text_parser(filepath, separator="="):
+    return_dict = {}
+    with open(filepath, "r") as f:
+        for line in f:
+            line = line.split(separator)
+            return_dict[line[0]] = line[1]
+    return return_dict
 
 def parseVMTParameter(line, parameters):
     words = []
@@ -43,26 +87,92 @@ def parseVMTParameter(line, parameters):
         
     key = words[0].strip('"')
     
-    if not key.startswith('$'):
+    if key.startswith('/'):
         return
-        
+    
+    if not key.startswith('$'):
+        if not key.startswith('include'):
+            return
+
     val = words[1].strip('\n')
     
-    parameters[key] = val
+    # remove comments, HACK
+    commentTuple = val.partition('//')
     
-def fixTexturePath(path):
-    retPath = path.strip().strip('"')
+    if(val.strip('"' + "'") == ""):
+        print("+ No value found, moving on")
+        return
+    
+    if not commentTuple[0] in parameters:
+        parameters[key] = commentTuple[0]
+  
+def fixTexturePath(p, addonString = ""):
+    retPath = p.strip().strip('"')
     retPath = retPath.replace('\\', '/') # Convert paths to use forward slashes.
     retPath = retPath.replace('.vtf', '') # remove any old extensions
-    retPath = '"materials/' + retPath + TEXTURE_FILEEXT + '"'
+    retPath = '"materials/' + retPath + addonString + TEXTURE_FILEEXT + '"'
     return retPath
 
 def fixVector(s):
-    s = s.strip('"[]{} ') # some VMT vectors use {}
+    s = s.strip('"][}{ ') # some VMT vectors use {}
     parts = [str(float(i)) for i in s.split(' ')]
     extra = (' 0.0' * max(3 - s.count(' '), 0) )
     return '"[' + ' '.join(parts) + extra + ']"'
 
+def extractAlphaTextures(localPath, invertColor):
+    image_path = PATH_TO_CONTENT_ROOT + localPath
+    mask_path = PATH_TO_CONTENT_ROOT + localPath[:-4] + "_alpha.tga"
+    print("+ Attempting to extract alpha from " + image_path)
+    
+    if path.exists(image_path):
+        print("+ Extracting alpha from " + image_path)
+        # Open the image and convert it to RGBA, just in case it was indexed
+        image = Image.open(image_path).convert('RGBA')
+
+        # Extract just the alpha channel
+        alpha = image.split()[-1]
+
+        # Unfortunately the alpha channel is still treated as such and can't be dumped
+        # as-is
+
+        # Create a new image with an opaque black background
+        bg = Image.new("RGBA", image.size, (0,0,0,255))
+
+        # Copy the alpha channel to the new image using itself as the mask
+        bg.paste(alpha)
+        
+        if invertColor:
+            r,g,b,a = bg.split()
+            rgb_image = Image.merge('RGB', (r,g,b))
+            inverted_image = PIL.ImageOps.invert(rgb_image)
+
+            r2,g2,b2 = inverted_image.split()
+
+            final_transparent_image = Image.merge('RGB', (r2,g2,b2))
+            
+            final_transparent_image.save(mask_path)
+        else:
+            bg.save(mask_path)
+                                                                        
+def flipNormalMap(localPath):
+    image_path = PATH_TO_CONTENT_ROOT + localPath
+    
+    if path.exists(image_path):
+        # Open the image and convert it to RGBA, just in case it was indexed
+        image = Image.open(image_path).convert('RGBA')
+
+        # Extract just the green channel
+        r,g,b,a = image.split()
+
+        g = PIL.ImageOps.invert(g)
+
+        final_transparent_image = Image.merge('RGBA', (r,g,b,a))
+        
+        final_transparent_image.save(image_path)
+
+#flipNormalMap("materials/models/player/demo/demoman_normal.tga")
+    
+#extractAlphaTextures("materials/models/bots/boss_bot/carrier_body.tga")
 
 def getVmatParameter(key, val):
     key = key.strip('$').lower()
@@ -73,7 +183,7 @@ def getVmatParameter(key, val):
         'basetexture': ('TextureColor', fixTexturePath, None),
         'bumpmap': ('TextureNormal', fixTexturePath, None),
         'envmap': ('F_SPECULAR', '1', '\tF_SPECULAR_CUBE_MAP 1\n\tF_SPECULAR_CUBE_MAP_PROJECTION 1\n\tg_flCubeMapBlurAmount "1.000"\n\tg_flCubeMapScalar "1.000"\n'), #Assumes env_cubemap
-        'envmaptint': ('TextureReflectance', fixVector, None),
+        #'envmaptint': ('TextureReflectance', fixVector, None),
         'envmapmask': ('TextureReflectance', fixTexturePath, None),
         'color': ('g_vColorTint', None, None), #Assumes being used with basetexture
         'selfillum': ('g_flSelfIllumScale', '"1.000"', None),
@@ -84,12 +194,12 @@ def getVmatParameter(key, val):
         'additive': ('F_ADDITIVE_BLEND', None, None),
         'nocull': ('F_RENDER_BACKFACES', None, None),
         'decal':( 'F_OVERLAY', None, None),
-        }
+		}
         
     if key in convert:
         outValue = val
         additionalLines = ''
-    
+        
         if isinstance(convert[key][1], str):
             outValue = convert[key][1]
         elif hasattr(convert[key][1], '__call__'):
@@ -99,6 +209,14 @@ def getVmatParameter(key, val):
             additionalLines = convert[key][2]
         elif hasattr(convert[key][2], '__call__'):
             additionalLines = convert[key][2](val)
+            
+        '''if isinstance(convert[key][3], bool):
+            if(val.replace('"', '') == "0" or val.replace('"', '') == "false"):
+                return ''
+        elif hasattr(convert[key][3], '__call__'):
+            print("Error: no bool at the end of dict!!")
+            return ''
+            '''
         
         return '\t' + convert[key][0] + ' ' + outValue + '\n' + additionalLines
         
@@ -113,41 +231,199 @@ def parseDir(dirName):
             
     return files
 
-print('\nSource 2 Material Conveter\n')
+###
+### Main Execution
+###
 
+globalVars = text_parser("global_vars.txt", " = ")
+PATH_TO_GAME_CONTENT_ROOT = globalVars["gameContentRoot"]
+PATH_TO_CONTENT_ROOT = PATH_TO_GAME_CONTENT_ROOT + sys.argv[1] + "/"
+
+if(PATH_TO_GAME_CONTENT_ROOT == ""):
+    print("ERROR: Please open vmt_to_vmat in your favorite text editor, and modify PATH_TO_GAME_CONTENT_ROOT to lead to your games content files (i.e. ...\steamvr_environments\content\steamtours_addons\)")
+    quit()
+
+print('Source 2 Material Conveter! By Rectus via Github.')
+print('Initially forked by Alpyne, this version by caseytube.')
+print('--------------------------------------------------------------------------------------------------------')
+
+# Verify file paths
 fileList = []
-
-for filePath in sys.argv:
-    absFilePath = os.path.abspath(filePath)
+if(len(sys.argv) == 3):
+    absFilePath = os.path.abspath(sys.argv[2])
     if os.path.isdir(absFilePath):
         fileList.extend(parseDir(absFilePath))
+    elif(absFilePath.lower().endswith('.vmt')):
+        fileList.append(absFilePath)
     else:
-        if absFilePath.lower().endswith('.vmt'):
-            fileList.append(absFilePath)
+        print("ERROR: File path is invalid. required format: vmt_to_vmat.py modName C:\optional\path\to\root")
+        quit()
+elif(len(sys.argv) == 2):
+    absFilePath = os.path.abspath(PATH_TO_CONTENT_ROOT)
+    print(PATH_TO_CONTENT_ROOT)
+    if os.path.isdir(absFilePath):
+        fileList.extend(parseDir(absFilePath))
+    elif(absFilePath.lower().endswith('.vmt')):
+        fileList.append(absFilePath)
+    else:
+        print("ERROR: File path is invalid. required format: vmt_to_vmat.py modName C:\optional\path\to\root")
+        quit()
+else:
+    print("ERROR: CMD Arguments are invalid. Required format: vmt_to_vmat.py modName C:\optional\path\to\root")
+    quit()
 
-    
+# Main function, loop through every .vmt
 for fileName in fileList:
-    
-    vmatFileName = fileName.replace('.vmt', '') + '.vmat'
-    
-    if os.path.exists(vmatFileName): continue
-    
-    print('Converting ' + os.path.basename(fileName))
-    
+    print('--------------------------------------------------------------------------------------------------------')
+    print('+ Loading File:\n' + fileName)
     vmtParameters = {}
-
+    validMaterial = False
+    validPatch = False
+    skipNextLine = False
+    
+    matType = ""
+    patchFile = ""
+    basetexturePath = ""
+    bumpmapPath = ""
+    phong = False; #also counts for rimlight since they feed off each other
+    baseMapAlphaPhongMask = False
+    envMap = False
+    baseAlphaEnvMapMask = False
+    normalMapAlphaEnvMapMask = False
+    selfIllum = False
+    translucent = False #also counts for alphatest
+    
     with open(fileName, 'r') as vmtFile:
         for line in vmtFile.readlines():
-            parseVMTParameter(line, vmtParameters)    
-
-    with open(vmatFileName, 'w') as vmatFile:
-        vmatFile.write('// Converted with vmt_to_vmat.py\n\n')
-        vmatFile.write('Layer0\n{\n\tshader "' + SHADER + '.vfx"\n\n')
-        for key, val in vmtParameters.items():
-            vmatFile.write(getVmatParameter(key, val))
-        if "metal" in vmatFileName:
-            vmatFile.write("\tg_flMetalness 1.000\n")
+            if any(wd in line.lower() for wd in materialTypes):
+                validMaterial = True
+                matType = line.lower()
+                
+            if skipNextLine:
+                if "]" in line or "}" in line:
+                    skipNextLine = False
+            else:
+                parseVMTParameter(line, vmtParameters)
             
-        vmatFile.write('}\n')
+            if any(wd in line.lower() for wd in ignoreList):
+                skipNextLine = True
+            
+    if "patch" in matType.lower():
+        patchFile = vmtParameters["include"].replace('"', '').replace("'", '');
+        print("+ Patching materials details from: " + patchFile)
+        with open(PATH_TO_CONTENT_ROOT + patchFile, 'r') as vmtFile:
+            for line in vmtFile.readlines():
+                if any(wd in line.lower() for wd in materialTypes):
+                    validPatch = True
+                parseVMTParameter(line, vmtParameters)
+                
+        if not validPatch:
+            print("+ Patch file is not a valid material. Skipping!")
+            continue
+    
+    if validMaterial:
+        vmatFileName = fileName.replace('.vmt', '') + '.vmat'
+        if os.path.exists(vmatFileName):
+            print('+ File already exists. Skipping!')
+            continue
+        
+        print('+ Converting ' + os.path.basename(fileName))
+        with open(vmatFileName, 'w') as vmatFile:
+            vmatFile.write('// Converted with vmt_to_vmat.py\n\n')
+            vmatFile.write('Layer0\n{\n\tshader "' + SHADER + '.vfx"\n\n')
+            for key, val in vmtParameters.items():
+                vmatFile.write(getVmatParameter(key, val))
+                if(key.lower() == "$phong" or key.lower() == "$rimlight"):
+                    if val.strip('"' + "'") != "0":
+                        phong = True
+                elif(key.lower() == "$basemapalphaphongmask"):
+                    if val.strip('"' + "'") != "0":
+                        baseMapAlphaPhongMask = True
+                elif(key.lower() == "$selfillum"):
+                    if val.strip('"' + "'") != "0":
+                        selfIllum = True
+                elif(key.lower() == "$translucent" or key == "$alphatest"):
+                    if val.strip('"' + "'") != "0":
+                        translucent = True
+                elif(key.lower() == "$basetexture"):
+                    basetexturePath = val.lower().strip()
+                elif(key.lower() == "$bumpmap"):
+                    bumpmapPath = val.lower().strip()
+                elif(key.lower() == "$envmap"):
+                    envMap = True
+                elif(key.lower() == "$basealphaenvmapmask"):
+                    if val.strip('"' + "'") != "0":
+                        baseAlphaEnvMapMask = True
+                elif(key.lower() == "$normalmapalphaenvmapmask"):
+                    if val.strip('"' + "'") != "0":
+                        normalMapAlphaEnvMapMask = True
+                    
+            #check if base texture is empty
+            if "metal" in vmatFileName:
+                vmatFile.write("\tg_flMetalness 1.000\n")
+            
+            if translucent:
+                vmatFile.write('\tF_TRANSLUCENT 1\n\tTextureTranslucency ' + fixTexturePath(basetexturePath, MAP_SUBSTRING) + '\n')
+                extractAlphaTextures("materials/" + basetexturePath.replace('"', '') + TEXTURE_FILEEXT, False)
+                
+            print(". " + bumpmapPath + " .")
+            if phong:
+                if baseMapAlphaPhongMask:
+                    vmatFile.write('\tF_METALNESS_TEXTURE 1\n\tTextureMetalness ' + fixTexturePath(basetexturePath, MAP_SUBSTRING) + '\n')
+                    extractAlphaTextures("materials/" + basetexturePath.replace('"', '') + TEXTURE_FILEEXT, True)
+                else:
+                    if(bumpmapPath == ''):
+                        vmatFile.write('\tF_METALNESS_TEXTURE 1\n\tTextureMetalness "[1.000000 1.000000 1.000000 0.000000]"\n')
+                        extractAlphaTextures("materials/" + basetexturePath.replace('"', '') + TEXTURE_FILEEXT, True)
+                    else:
+                        vmatFile.write('\tF_METALNESS_TEXTURE 1\n\tTextureMetalness ' + fixTexturePath(bumpmapPath, MAP_SUBSTRING) + '\n')
+                        extractAlphaTextures("materials/" + bumpmapPath.replace('"', '') + TEXTURE_FILEEXT, True)
+            if envMap:
+                if baseAlphaEnvMapMask:
+                    vmatFile.write('\tg_vReflectanceRange "[0.000 0.050]"\n\tTextureReflectance ' + fixTexturePath(basetexturePath, MAP_SUBSTRING) + '\n')
+                    extractAlphaTextures("materials/" + basetexturePath.replace('"', '') + TEXTURE_FILEEXT, False)
+                if normalMapAlphaEnvMapMask:
+                    vmatFile.write('\tg_vReflectanceRange "[0.000 0.050]"\n\tTextureReflectance ' + fixTexturePath(bumpmapPath, MAP_SUBSTRING) + '\n')
+                    extractAlphaTextures("materials/" + bumpmapPath.replace('"', '') + TEXTURE_FILEEXT, False)
+            
+            if (selfIllum):
+                vmatFile.write('\tF_SELF_ILLUM 1\n\tTextureSelfIllumMask ' + fixTexturePath(basetexturePath, MAP_SUBSTRING) + '\n')
+                extractAlphaTextures("materials/" + basetexturePath.replace('"', '') + TEXTURE_FILEEXT, False)
+                
+            vmatFile.write('}\n')
+    
+    bumpmapConvertedList = PATH_TO_CONTENT_ROOT + "/convertedBumpmaps.txt"
+    #if os.path.exists(bumpmapConvertedList): continue
+    
+    # flip the green channels of any normal maps
+    if(bumpmapPath != ""):
+        print("Checking if normal file " + bumpmapPath + " has been converted")
+        foundMaterial = False
+        with open(bumpmapConvertedList, 'r+') as bumpList: #change the read type to write
+            for line in bumpList.readlines():
+                if line.rstrip() == bumpmapPath.rstrip():
+                    foundMaterial = True
+        
+            if not foundMaterial:
+                flipNormalMap(fixTexturePath(bumpmapPath).strip("'" + '"'))
+                print("flipped normal map of " + bumpmapPath)
+                #append bumpmapPath to bumpmapCovertedList
+                bumpList.write(bumpmapPath + "\n")
+                bumpList.close()
+        
+# TODO: reparse the vmt, see i.e. if alphatest, then TextureTranslucency "path/to/tex/name_alpha.tga",
+# basemap alpha can either be a transparency mask, selfillum mask, or specular mask
+# normalmap alpha can be a phong mask by default
+
+# if $translucent/$alphatest
+	# TextureTranslucency "path/to/tex/basetexture_alpha.tga"
+# if $rimlight/$phong in vmt
+	# if $basemapalphaphongmask in vmt
+		#TextureRimMask/TextureSpecularMask "path/to/tex/basetexture_alpha.tga"
+	# else
+		#TextureRimMask/TextureSpecularMask "path/to/tex/bumpmap_alpha.tga"
+# if $selfillum in vmt
+	# Add Mask 1
+	# TextureSelfIllumMask "path/to/tex/basetexture_alpha.tga"
 
 # input("\nDone, press ENTER to continue...")

--- a/utils/vmt_to_vmat.py
+++ b/utils/vmt_to_vmat.py
@@ -55,6 +55,7 @@ materialTypes = [
 #"modulate",
 #"water", #TODO: integrate water/refract shaders into this script
 "refract",
+"worldvertextransition",
 #"lightmapped_4wayblend",
 #"unlittwotexture", #TODO: Fix this one too, used by some hl2 mats
 #"lightmappedreflective",
@@ -190,6 +191,7 @@ def getVmatParameter(key, val):
     convert = {
         #VMT paramter: VMAT parameter, value, additional lines to add. The last two variables take functions or strings, or None for using the old value.
         'basetexture': ('TextureColor', fixTexturePath, None),
+        'basetexture2': ('TextureLayer1Color', fixTexturePath, None),
         'bumpmap': ('TextureNormal', fixTexturePath, None),
         'normalmap': ('TextureNormal', fixTexturePath, None),
         'envmap': ('F_SPECULAR', '1', '\tF_SPECULAR_CUBE_MAP 1\n\tF_SPECULAR_CUBE_MAP_PROJECTION 1\n\tg_flCubeMapBlurAmount "1.000"\n\tg_flCubeMapScalar "1.000"\n'), #Assumes env_cubemap
@@ -304,6 +306,7 @@ for fileName in fileList:
     normalMapAlphaEnvMapMask = False
     selfIllum = False
     translucent = False #also counts for alphatest
+    alphatest = False
     
     with open(fileName, 'r') as vmtFile:
         for line in vmtFile.readlines():
@@ -355,9 +358,12 @@ for fileName in fileList:
                     if val.strip('"' + "'") != "0":
                         print("selfillum")
                         selfIllum = True
-                elif(key.lower() == "$translucent" or key == "$alphatest"):
+                elif(key.lower() == "$translucent"):
                     if val.strip('"' + "'") != "0":
                         translucent = True
+                elif(key.lower() == "$alphatest"):
+                    if val.strip('"' + "'") != "0":
+                        alphatest = True
                 elif(key.lower() == "$basetexture"):
                     basetexturePath = val.lower().strip().replace('.vtf', '')
                 elif(key.lower() == "$bumpmap"):
@@ -380,6 +386,10 @@ for fileName in fileList:
             
             if translucent:
                 vmatFile.write('\tF_TRANSLUCENT 1\n\tTextureTranslucency ' + fixTexturePath(basetexturePath, MAP_SUBSTRING) + '\n')
+                extractAlphaTextures("materials/" + basetexturePath.replace('"', '') + TEXTURE_FILEEXT, False)
+                
+            if alphatest:
+                vmatFile.write('\tF_ALPHA_TEST 1\n\tTextureTranslucency ' + fixTexturePath(basetexturePath, MAP_SUBSTRING) + '\n')
                 extractAlphaTextures("materials/" + basetexturePath.replace('"', '') + TEXTURE_FILEEXT, False)
                 
             if phong:

--- a/utils/vmt_to_vmat_dota.py
+++ b/utils/vmt_to_vmat_dota.py
@@ -1,0 +1,336 @@
+# Converts Source 1 .vmt material files to simple Source 2 .vmat files.
+#
+# Copyright (c) 2016 Rectus
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import sys
+import os
+import re
+from PIL import Image
+import PIL.ImageOps    
+
+GAMEISTF2 = True;
+SHADER = 'hero' # What shader to use.
+TEXTURE_FILEEXT = '.tga' # File format of the textures.
+MAP_SUBSTRING = '_alpha' # substring added after an alpha map's name, but before the extension
+PATH_TO_CONTENT_ROOT = 'F:/Programs/Steam/steamapps/common/dota 2 beta/content/dota_addons/hl2/' # this leads to the root of the game folder, i.e. dota 2 beta/content/dota_addons/tf/, make sure to remember the final /
+
+def parseVMTParameter(line, parameters):
+    words = []
+    
+    if line.startswith('\t') or line.startswith(' '):
+        words = re.split(r'\s+', line, 2)
+    else:
+        words = re.split(r'\s+', line, 1)
+        
+    words = list(filter(len, words))
+    if len(words) < 2:
+        return 
+        
+    key = words[0].strip('"')
+    
+    if key.startswith('/'):
+        return
+    
+    if not key.startswith('$'):
+        return
+
+    val = words[1].strip('\n')
+    
+    # remove comments, HACK
+    commentTuple = val.partition('//')
+    
+    if(val.strip('"' + "'") == ""):
+        print("no value found, moving on")
+        return
+    
+    parameters[key] = commentTuple[0]
+    
+def fixTexturePath(path, addonString = ""):
+    retPath = path.strip().strip('"')
+    retPath = retPath.replace('\\', '/') # Convert paths to use forward slashes.
+    retPath = retPath.replace('.vtf', '') # remove any old extensions
+    retPath = '"materials/' + retPath + addonString + TEXTURE_FILEEXT + '"'
+    return retPath
+
+def fixVector(s):
+    s = s.strip('"[]{} ') # some VMT vectors use {}
+    parts = [str(float(i)) for i in s.split(' ')]
+    extra = (' 0.0' * max(3 - s.count(' '), 0) )
+    return '"[' + ' '.join(parts) + extra + ']"'
+
+def extractAlphaTextures(localPath):
+    image_path = PATH_TO_CONTENT_ROOT + localPath
+    mask_path = PATH_TO_CONTENT_ROOT + localPath[:-4] + "_alpha.tga"
+
+    # Open the image and convert it to RGBA, just in case it was indexed
+    image = Image.open(image_path).convert('RGBA')
+
+    # Extract just the alpha channel
+    alpha = image.split()[-1]
+
+    # Unfortunately the alpha channel is still treated as such and can't be dumped
+    # as-is
+
+    # Create a new image with an opaque black background
+    bg = Image.new("RGBA", image.size, (0,0,0,255))
+
+    # Copy the alpha channel to the new image using itself as the mask
+    bg.paste(alpha, mask=alpha)
+
+    # Since the bg image started as RGBA, we can save some space by converting it
+    # to grayscale ('L') Optionally, we can convert the image to be indexed which
+    # saves some more space ('P') In my experience, converting directly to 'P'
+    # produces both the Gray channel and an Alpha channel when viewed in GIMP,
+    # althogh the file sizes is about the same
+    bg.convert('L').convert('P', palette=Image.ADAPTIVE, colors=8).save(
+                                                                    mask_path,
+                                                                    optimize=True)
+                                                                    
+def flipNormalMap(localPath):
+    image_path = PATH_TO_CONTENT_ROOT + localPath
+    #mask_path = PATH_TO_CONTENT_ROOT + localPath[:-4] + "_alpha.tga"
+
+    # Open the image and convert it to RGBA, just in case it was indexed
+    image = Image.open(image_path).convert('RGBA')
+
+    # Extract just the green channel
+    r,g,b,a = image.split()
+
+    g = PIL.ImageOps.invert(g)
+
+    final_transparent_image = Image.merge('RGBA', (r,g,b,a))
+    
+    final_transparent_image.save(image_path)
+
+#flipNormalMap("materials/models/player/demo/demoman_normal.tga")
+    
+#extractAlphaTextures("materials/models/bots/boss_bot/carrier_body.tga")
+
+def getVmatParameter(key, val):
+    key = key.strip('$').lower()
+    
+    # Dict for converting parameters
+    convert = {
+        #VMT paramter: VMAT parameter, value, additional lines to add. The last two variables take functions or strings, or None for using the old value.
+        # fixTexturePath(val, "_test") if you want to add a value to the end of a path but before .tga
+        'basetexture': ('TextureColor', fixTexturePath, '\tg_flAmbientScale "0.000"\n', False), # use this for default variables too, like ambient scale
+        'bumpmap': ('TextureNormal', fixTexturePath, None, False),
+        'color': ('g_vColorTint', None, None, False), #Assumes being used with basetexture
+        'translucent': ('F_TRANSLUCENT', None, '\tg_flOpacityScale "1.000"\n', True),
+		'alphatest': ('F_ALPHA_TEST', None, '\tg_flAlphaTestReference "0.500"\n', True),
+        'additive': ('F_ADDITIVE_BLEND', None, None, True),
+        'nocull': ('F_RENDER_BACKFACES', None, None, True),
+        'decal':( 'F_OVERLAY', None, None, True),
+        
+        'envmap': ('F_SPECULAR', '1', '\tF_SPECULAR_CUBE_MAP 1\n\tF_SPECULAR_CUBE_MAP_PROJECTION 1\n\tg_flCubeMapBlurAmount "1.000"\n\tg_flCubeMapScalar "1.000"\n', True), #Assumes env_cubemap
+        'envmaptint': ('TextureReflectance', fixVector, None, False),
+        'envmapmask': ('TextureReflectance', fixTexturePath, None, False),
+		
+        # we don't need detail mask or any of this stuff unless the user chooses to
+        'selfillum': ('g_flSelfIllumScale', '"1.000"', '\tF_MASKS_1 1\n\tTextureDetailMask "[0.000000 0.000000 0.000000 0.000000]"\n\tTextureDiffuseWarpMask "[0.000000 0.000000 0.000000 0.000000]"\n\tTextureMetalnessMask "[0.000000 0.000000 0.000000 0.000000]"\n', True),
+        'selfillumtint': ('g_vSelfIllumTint', None, None, False),
+        'selfillummask': ('TextureSelfIllumMask', fixTexturePath, None, False),
+		
+		'phong': ('g_flSpecularScale', None, '\tF_MASKS_2 1\n', True),
+		'phongexponent': ('g_flSpecularExponent', None, None, False),
+        'phongfresnelranges': ('//fresnelcomment', None, None, False),
+        #'phongexponenttexture': ('TextureSpecularMask', fixTexturePath, None),
+		
+		'rimlight': ('g_flRimLightScale', None, '\tF_MASKS_2 1\n', False),
+		'rimexponent': ('g_flRimLightScale', None, None, False),
+		#'rimmask': ('TextureRimMask', None, None, True),
+		
+		'lightwarptexture': ('TextureFresnelWarpSpec', fixTexturePath, '\tTextureFresnelWarpColor ' + fixTexturePath(val) + '\n', False),
+		
+        # currently blanking this because TF2 uses detail for fire textures
+		#'detail': ('TextureDetail', fixTexturePath, '\tF_DETAIL 1\n'),
+		#'detailscale': ('g_vDetailTexCoordScale', '"[' + val + ' ' + val + ']"', None),
+		#'detailblendfactor': ('g_flDetailBlendFactor', None, None),
+		#note to self: create a function to fix values?
+		}
+        
+    if key in convert:
+        outValue = val
+        additionalLines = ''
+        
+        if isinstance(convert[key][1], str):
+            outValue = convert[key][1]
+        elif hasattr(convert[key][1], '__call__'):
+            outValue = convert[key][1](val)
+
+        if isinstance(convert[key][2], str):
+            additionalLines = convert[key][2]
+        elif hasattr(convert[key][2], '__call__'):
+            additionalLines = convert[key][2](val)
+            
+        '''if isinstance(convert[key][3], bool):
+            if(val.replace('"', '') == "0" or val.replace('"', '') == "false"):
+                return ''
+        elif hasattr(convert[key][3], '__call__'):
+            print("Error: no bool at the end of dict!!")
+            return ''
+            '''
+        
+        return '\t' + convert[key][0] + ' ' + outValue + '\n' + additionalLines
+        
+    return ''
+
+def parseDir(dirName):
+    files = []
+    for root, dirs, fileNames in os.walk(dirName):
+        for fileName in fileNames:	
+            if fileName.lower().endswith('.vmt'):
+                files.append(os.path.join(root,fileName))
+            
+    return files
+
+print('\nSource 2 Material Conveter\n')
+
+fileList = []
+
+for filePath in sys.argv:
+    absFilePath = os.path.abspath(filePath)
+    if os.path.isdir(absFilePath):
+        fileList.extend(parseDir(absFilePath))
+    else:
+        if absFilePath.lower().endswith('.vmt'):
+            fileList.append(absFilePath)
+
+    
+for fileName in fileList:
+    
+    vmtParameters = {}
+    # material types need to be lowercase because python is a bit case sensitive
+    materialTypes = [
+    "vertexlitgeneric",
+    "unlitgeneric",
+    "lightmappedgeneric",
+    #"modulate",
+    #"water", #TODO: integrate water/refract shaders into this script
+    #"refract"
+    #"lightmapped_4wayblend",
+    #"lightmappedreflective",
+    #"cables"
+    ]
+    validMaterial = False;
+    
+    basetexturePath = ""
+    bumpmapPath = ""
+    phong = False; #also counts for rimlight since they feed off each other
+    baseMapAlphaPhongMask = False
+    selfIllum = False
+    translucent = False #also counts for alphatest
+    
+    with open(fileName, 'r') as vmtFile:
+        for line in vmtFile.readlines():
+            if any(wd in line.lower() for wd in materialTypes):
+                validMaterial = True
+            parseVMTParameter(line, vmtParameters)
+    
+    if validMaterial:
+        print('Converting ' + os.path.basename(fileName))
+        
+        vmatFileName = fileName.replace('.vmt', '') + '.vmat'
+        
+        if os.path.exists(vmatFileName): continue
+        
+        with open(vmatFileName, 'w') as vmatFile:
+            vmatFile.write('// Converted with vmt_to_vmat.py\n\n')
+            vmatFile.write('Layer0\n{\n\tshader "' + SHADER + '.vfx"\n\n')
+            for key, val in vmtParameters.items():
+                vmatFile.write(getVmatParameter(key, val))
+                if(key.lower() == "$phong" or key.lower() == "$rimlight"):
+                    if val.strip('"' + "'") != "0":
+                        phong = True
+                elif(key.lower() == "$basemapalphaphongmask"):
+                    if val.strip('"' + "'") != "0":
+                        baseMapAlphaPhongMask = True
+                elif(key.lower() == "$selfillum"):
+                    if val.strip('"' + "'") != "0":
+                        selfIllum = True
+                elif(key.lower() == "$translucent" or key == "$alphatest"):
+                    if val.strip('"' + "'") != "0":
+                        translucent = True
+                elif(key.lower() == "$basetexture"):
+                    basetexturePath = val.lower()
+                elif(key.lower() == "$bumpmap"):
+                    bumpmapPath = val.lower()
+            
+            if "metal" in vmatFileName:
+                vmatFile.write("\tg_flMetalness 1.000\n")
+            
+            if translucent:
+                vmatFile.write('\tTextureTranslucency ' + fixTexturePath(basetexturePath, MAP_SUBSTRING) + '\n')
+                extractAlphaTextures("materials/" + basetexturePath.replace('"', '') + TEXTURE_FILEEXT)
+                
+            if phong:
+                if baseMapAlphaPhongMask:
+                    vmatFile.write('\tTextureRimMask ' + fixTexturePath(basetexturePath, MAP_SUBSTRING) + '\n\tTextureSpecularMask ' + fixTexturePath(basetexturePath, MAP_SUBSTRING) + '\n')
+                    extractAlphaTextures("materials/" + basetexturePath.replace('"', '') + TEXTURE_FILEEXT)
+                else:
+                    if(bumpmapPath == ''):
+                        vmatFile.write('\tTextureSpecularMask "[1.000000 1.000000 1.000000 0.000000]"\n\tTextureRimMask "[1.000000 1.000000 1.000000 0.000000]"\n')
+                        extractAlphaTextures("materials/" + basetexturePath.replace('"', '') + TEXTURE_FILEEXT)
+                    else:
+                        vmatFile.write('\tTextureSpecularMask ' + fixTexturePath(bumpmapPath, MAP_SUBSTRING) + '\n\tTextureRimMask ' + fixTexturePath(bumpmapPath, MAP_SUBSTRING) + '\n')
+                        extractAlphaTextures("materials/" + bumpmapPath.replace('"', '') + TEXTURE_FILEEXT)
+            
+            if (selfIllum):
+                vmatFile.write('\tTextureSelfIllumMask ' + fixTexturePath(basetexturePath, MAP_SUBSTRING) + '\n')
+                extractAlphaTextures("materials/" + basetexturePath.replace('"', '') + TEXTURE_FILEEXT)
+            
+            vmatFile.write('}\n')
+    
+    bumpmapConvertedList = PATH_TO_CONTENT_ROOT + "convertedBumpmaps.txt"
+    print(bumpmapConvertedList)
+    #if os.path.exists(bumpmapConvertedList): continue
+    
+    # flip the green channels of any normal maps
+    if(bumpmapPath != ""):
+        foundMaterial = False
+        with open(bumpmapConvertedList, 'r+') as bumpList: #change the read type to write
+            for line in bumpList.readlines():
+                if line.rstrip() == bumpmapPath.rstrip():
+                    foundMaterial = True
+        
+            if not foundMaterial:
+                flipNormalMap(fixTexturePath(bumpmapPath).strip("'" + '"'))
+                print("flipped normal map")
+                #append bumpmapPath to bumpmapCovertedList
+                bumpList.write(bumpmapPath + "\n")
+                bumpList.close()
+        
+# TODO: reparse the vmt, see i.e. if alphatest, then TextureTranslucency "path/to/tex/name_alpha.tga",
+# basemap alpha can either be a transparency mask, selfillum mask, or specular mask
+# normalmap alpha can be a phong mask by default
+
+# if $translucent/$alphatest
+	# TextureTranslucency "path/to/tex/basetexture_alpha.tga"
+# if $rimlight/$phong in vmt
+	# if $basemapalphaphongmask in vmt
+		#TextureRimMask/TextureSpecularMask "path/to/tex/basetexture_alpha.tga"
+	# else
+		#TextureRimMask/TextureSpecularMask "path/to/tex/bumpmap_alpha.tga"
+# if $selfillum in vmt
+	# Add Mask 1
+	# TextureSelfIllumMask "path/to/tex/basetexture_alpha.tga"
+
+# input("\nDone, press ENTER to continue...")

--- a/utils/working files/vmf_convert.py
+++ b/utils/working files/vmf_convert.py
@@ -1,5 +1,4 @@
-# cmd command: python mdl_to_vmdl.py "C:\Program Files (x86)\Steam\steamapps\common\SteamVR\tools\steamvr_environments\content\steamtours_addons\l4d2_converted\models"
-# MUST run in the models folder
+# cmd command: python vmf_convert.py "C:\path\to\vmf\file.vmf"
 
 import re, sys, os
 
@@ -8,8 +7,8 @@ INPUT_FILE_EXT = '.vmf'
 PATH_TO_GAME_CONTENT_ROOT = ""
 PATH_TO_CONTENT_ROOT = ""
     
-print('Source 2 .vmf Prepper! By caseytube via Github')
-print('Converts .vmf files to be ready for Source 2')
+print('Source 2 .vmf Prepper! EXPERIMENTAL!! By caseytube via Github')
+print('Converts .vmf files to be ready for Source 2 by fixing materials')
 print('--------------------------------------------------------------------------------------------------------')
 
 filename = sys.argv[1]

--- a/utils/working files/vmf_convert.py
+++ b/utils/working files/vmf_convert.py
@@ -1,0 +1,44 @@
+# cmd command: python mdl_to_vmdl.py "C:\Program Files (x86)\Steam\steamapps\common\SteamVR\tools\steamvr_environments\content\steamtours_addons\l4d2_converted\models"
+# MUST run in the models folder
+
+import re, sys, os
+
+INPUT_FILE_EXT = '.vmf'
+# this leads to the root of the game folder, i.e. dota 2 beta/content/dota_addons/, make sure to remember the final slash!!
+PATH_TO_GAME_CONTENT_ROOT = ""
+PATH_TO_CONTENT_ROOT = ""
+    
+print('Source 2 .vmf Prepper! By caseytube via Github')
+print('Converts .vmf files to be ready for Source 2')
+print('--------------------------------------------------------------------------------------------------------')
+
+filename = sys.argv[1]
+convertedFilename = filename.replace('.vmf', '') + 'Converted.vmf'
+if not os.path.exists(filename):
+    print("input file doesn't exist")
+    quit()
+
+print('Importing', os.path.basename(filename))
+
+with open(convertedFilename, 'w') as convFile:
+    with open(filename, 'r') as vmfFile:
+        for line in vmfFile.readlines():
+            splitLine = line.replace('"', '').replace("'", "").split()
+            last = len(splitLine) - 1
+            
+            if "uaxis" in line:
+                oldVar = splitLine[last]
+                print(oldVar)
+                newVar = float(oldVar) * 32
+                print(newVar)
+                newLine = line.replace(str(oldVar), str(newVar))
+                convFile.write(newLine)
+            elif "vaxis" in line:
+                oldVar = splitLine[last]
+                print(oldVar)
+                newVar = float(oldVar) * 32
+                print(newVar)
+                newLine = line.replace(str(oldVar), str(newVar))
+                convFile.write(newLine)
+            else:
+                convFile.write(line)


### PR DESCRIPTION
Hi, would you consider modifying the VMF-VMAP conversion into another new script to support Call of Duty Black Ops 3 as well ?

Halflife Alyx has now been released, and VRF is able to decompile the VPK files which leaves us with directories full of PNG files, but only .vmat files to be able to import them with.
Call of Duty GDT's are very similar, and I feel someone that knows coding would be able to do this quite easily.
I have attached a basic_concrete.vmat (from HL:Alyx and a concrete.gdt for comparison

The VMAT to GDT conversion would be:
g_tColor -> colorMap
g_tNormal -> normalMap
g_tAmbientOcclusion -> occMap
Obviously the vtex extension would be replaced with png, but the paths should all be exactly the same.
There are two more keys in GDT - cosinePowerMap and specColorMap (gloss and specular) which it doesn't look like it's used in VMAT, so those keys' values can be blank or be replaced with $gloss and $specular respectively.
I have put "changeme0" in the material name (which is the filename without the extension)

Also, I have put "changeme1" at the textures' keys.
e.g. "colorMap" "i_changeme1_c" (the i_ and _c must remain with changeme1 being the material name. (then there's the normal and occlusion)
and at a second place I have changeme2. If you can transfer the entire path from the VMAP file, this entire keys' value can be replaced. (but you must leave the "texture_assets\\ in front.)
"i_changeme1_c" ( "image.gdf" )
	{
		"arabicUnsafe" "0"
		"baseImage" "texture_assets\\custom_textures\\COD2\\changeme2.png"

I understand if you're not really interested in doing this, but you never know if you don't ask. :)
But if you are interested, I'm happy to test for you.
I can be reached on here, or via discord https://discord.gg/Cakuqty
Thanks in advance 👍 

[VMAT_to_GDT.zip](https://github.com/DankParrot/source2utils/files/4397246/VMAT_to_GDT.zip)


